### PR TITLE
✨ Add custom claim decoding

### DIFF
--- a/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/IdTokenCirceDecoder.scala
+++ b/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/IdTokenCirceDecoder.scala
@@ -7,9 +7,7 @@ import me.wojnowski.oidc4s.Issuer
 
 import java.time.Instant
 
-trait IdTokenCirceDecoder {
-  private implicit val issuerDecoder: Decoder[Issuer] =
-    Decoder[String].map(Issuer.apply)
+trait IdTokenCirceDecoder extends IssuerCirceDecoder {
   private implicit val subjectDecoder: Decoder[Subject] =
     Decoder[String].map(Subject.apply)
   private implicit val audienceDecoder: Decoder[Audience] =

--- a/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/IssuerCirceDecoder.scala
+++ b/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/IssuerCirceDecoder.scala
@@ -1,0 +1,9 @@
+package me.wojnowski.oidc4s.json.circe
+
+import io.circe.Decoder
+import me.wojnowski.oidc4s.Issuer
+
+trait IssuerCirceDecoder {
+  protected implicit val issuerDecoder: Decoder[Issuer] =
+    Decoder[String].map(Issuer.apply)
+}

--- a/core/src/main/scala/me/wojnowski/oidc4s/json/JsonDecoder.scala
+++ b/core/src/main/scala/me/wojnowski/oidc4s/json/JsonDecoder.scala
@@ -1,9 +1,19 @@
 package me.wojnowski.oidc4s.json
 
+import me.wojnowski.oidc4s.Issuer
+
 trait JsonDecoder[A] {
   def decode(raw: String): Either[String, A]
 }
 
 object JsonDecoder {
   def apply[A](implicit decoder: JsonDecoder[A]): JsonDecoder[A] = decoder
+
+  /** Hint: implemented as part of specific JsonSupport implementations */
+  type ClaimsDecoder[A] = JsonDecoder[(A, Issuer)]
+
+  object ClaimsDecoder {
+    def apply[A](implicit decoder: ClaimsDecoder[A]): ClaimsDecoder[A] = decoder
+  }
+
 }


### PR DESCRIPTION
This PR introduces a single-step `verifyAndDecodeCustom` method as a replacement for `verifyAndDecodeFullResult`, which required to decode JSON twice.

Access to partially-decoded JWT header is lost, but it wasn't that useful anyway and we can bring it back on request.