### PR TITLE
♻️ 👌 Remove Algorithm.Other

### DIFF
--- a/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/JoseHeaderCirceDecoder.scala
+++ b/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/JoseHeaderCirceDecoder.scala
@@ -3,11 +3,14 @@ package me.wojnowski.oidc4s.json.circe
 import io.circe.Decoder
 import me.wojnowski.oidc4s.Algorithm
 import me.wojnowski.oidc4s.JoseHeader
+import me.wojnowski.oidc4s.json.JsonSupport
 
 trait JoseHeaderCirceDecoder {
 
   private implicit val jwtAlgorithmCirceDecoder: Decoder[Algorithm] =
-    Decoder[String].emap(shortName => Algorithm.findByShortName(shortName).toRight(s"Unsupported algorithm: $shortName"))
+    Decoder[String].emap { shortName =>
+      Algorithm.findByShortName(shortName).toRight(s"${JsonSupport.unsupportedAlgorithmErrorPrefix}$shortName")
+    }
 
   protected implicit val joseHeaderCirceDecoder: Decoder[JoseHeader] =
     Decoder.forProduct2[JoseHeader, String, Algorithm]("kid", "alg")(JoseHeader.apply)

--- a/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/JoseHeaderCirceDecoder.scala
+++ b/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/JoseHeaderCirceDecoder.scala
@@ -2,6 +2,7 @@ package me.wojnowski.oidc4s.json.circe
 
 import io.circe.Decoder
 import me.wojnowski.oidc4s.Algorithm
+import me.wojnowski.oidc4s.IdTokenVerifier.Error.UnsupportedAlgorithm
 import me.wojnowski.oidc4s.JoseHeader
 import me.wojnowski.oidc4s.json.JsonSupport
 
@@ -9,7 +10,7 @@ trait JoseHeaderCirceDecoder {
 
   private implicit val jwtAlgorithmCirceDecoder: Decoder[Algorithm] =
     Decoder[String].emap { shortName =>
-      Algorithm.findByShortName(shortName).toRight(s"${JsonSupport.unsupportedAlgorithmErrorPrefix}$shortName")
+      Algorithm.findByShortName(shortName).toRight(UnsupportedAlgorithm(shortName).toRawError)
     }
 
   protected implicit val joseHeaderCirceDecoder: Decoder[JoseHeader] =

--- a/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/JoseHeaderCirceDecoder.scala
+++ b/circe/src/main/scala/me/wojnowski/oidc4s/json/circe/JoseHeaderCirceDecoder.scala
@@ -7,7 +7,7 @@ import me.wojnowski.oidc4s.JoseHeader
 trait JoseHeaderCirceDecoder {
 
   private implicit val jwtAlgorithmCirceDecoder: Decoder[Algorithm] =
-    Decoder[String].map(Algorithm.fromString)
+    Decoder[String].emap(shortName => Algorithm.findByShortName(shortName).toRight(s"Unsupported algorithm: $shortName"))
 
   protected implicit val joseHeaderCirceDecoder: Decoder[JoseHeader] =
     Decoder.forProduct2[JoseHeader, String, Algorithm]("kid", "alg")(JoseHeader.apply)

--- a/core/src/main/scala/me/wojnowski/oidc4s/Algorithm.scala
+++ b/core/src/main/scala/me/wojnowski/oidc4s/Algorithm.scala
@@ -12,11 +12,9 @@ object Algorithm {
   case object Rs384 extends Algorithm(name = "RS384", fullName = "SHA384withRSA")
   case object Rs512 extends Algorithm(name = "RS512", fullName = "SHA512withRSA")
 
-  case class Other(override val name: String) extends Algorithm(name, fullName = name)
-
   implicit val order: Order[Algorithm] = Order.by(_.name)
 
   val supportedAlgorithms: NonEmptySet[Algorithm] = NonEmptySet.of(Rs256, Rs384, Rs512)
 
-  def fromString(s: String): Algorithm = supportedAlgorithms.find(_.name === s).getOrElse(Other(s))
+  def findByShortName(s: String): Option[Algorithm] = supportedAlgorithms.find(_.name === s)
 }

--- a/core/src/main/scala/me/wojnowski/oidc4s/json/JsonSupport.scala
+++ b/core/src/main/scala/me/wojnowski/oidc4s/json/JsonSupport.scala
@@ -11,3 +11,7 @@ trait JsonSupport {
   implicit def openIdConfigDecoder: JsonDecoder[OpenIdConfig]
   implicit def jwksDecoder: JsonDecoder[JsonWebKeySet]
 }
+
+object JsonSupport {
+  private[oidc4s] val unsupportedAlgorithmErrorPrefix = "Unsupported algorithm: "
+}

--- a/core/src/main/scala/me/wojnowski/oidc4s/json/JsonSupport.scala
+++ b/core/src/main/scala/me/wojnowski/oidc4s/json/JsonSupport.scala
@@ -11,7 +11,3 @@ trait JsonSupport {
   implicit def openIdConfigDecoder: JsonDecoder[OpenIdConfig]
   implicit def jwksDecoder: JsonDecoder[JsonWebKeySet]
 }
-
-object JsonSupport {
-  private[oidc4s] val unsupportedAlgorithmErrorPrefix = "Unsupported algorithm: "
-}

--- a/core/src/test/scala/me/wojnowski/oidc4s/IdTokenVerifierTest.scala
+++ b/core/src/test/scala/me/wojnowski/oidc4s/IdTokenVerifierTest.scala
@@ -15,6 +15,7 @@ import me.wojnowski.oidc4s.config.Location
 import me.wojnowski.oidc4s.config.OpenIdConfig
 import me.wojnowski.oidc4s.config.OpenIdConnectDiscovery
 import me.wojnowski.oidc4s.json.JsonDecoder
+import me.wojnowski.oidc4s.json.JsonSupport
 import me.wojnowski.oidc4s.mocks.CacheMock
 import me.wojnowski.oidc4s.mocks.HttpTransportMock
 import me.wojnowski.oidc4s.mocks.JsonSupportMock
@@ -404,8 +405,8 @@ object IdTokenVerifierTest {
       List(
         Right(JoseHeader(keyId = "f9d97b4cae90bcd76aeb20026f6b770cac221783", algorithm = Algorithm.Rs256)),
         Right(JoseHeader(keyId = "11e03f39b8d300c8c9a1b800ddebfcfde4152c0c", algorithm = Algorithm.Rs256)),
-        Left("Unsupported algorithm: none"),
-        Left("Unsupported algorithm: HS256")
+        Left(s"${JsonSupport.unsupportedAlgorithmErrorPrefix}none"),
+        Left(s"${JsonSupport.unsupportedAlgorithmErrorPrefix}HS256")
       )
 
   }

--- a/core/src/test/scala/me/wojnowski/oidc4s/OpenIdConnectDiscoveryTest.scala
+++ b/core/src/test/scala/me/wojnowski/oidc4s/OpenIdConnectDiscoveryTest.scala
@@ -20,7 +20,7 @@ class OpenIdConnectDiscoveryTest extends FunSuite {
       )
     val transport = HttpTransportMock.const[Id](configurationUrl, response = "correct-config-response")
     val jsonSupport = JsonSupportMock.instance(openIdConfigTranslations = { case "correct-config-response" =>
-      expectedConfig
+      Right(expectedConfig)
     })
 
     val discovery =

--- a/core/src/test/scala/me/wojnowski/oidc4s/PropertyIdTokenVerifierTest.scala
+++ b/core/src/test/scala/me/wojnowski/oidc4s/PropertyIdTokenVerifierTest.scala
@@ -89,7 +89,7 @@ class PropertyIdTokenVerifierTest extends CatsEffectSuite with ScalaCheckEffectS
       IdTokenVerifier.static(
         publicKeyProvider,
         issuer,
-        JsonSupportMock.instance(Map(rawClaims -> claims), Map(rawHeader -> header))
+        JsonSupportMock.instance(Map(rawClaims -> Right(claims)), Map(rawHeader -> Right(header)))
       )
 
     val rawJwt =

--- a/core/src/test/scala/me/wojnowski/oidc4s/PublicKeyProviderTest.scala
+++ b/core/src/test/scala/me/wojnowski/oidc4s/PublicKeyProviderTest.scala
@@ -61,7 +61,7 @@ class PublicKeyProviderTest extends CatsEffectSuite {
 
   private val transport = HttpTransportMock.const[Id](jwksUrl, "")
 
-  private val jsonSupport = JsonSupportMock.instance(jsonWebKeySetTranslations = { _ => jsonWebKeySet })
+  private val jsonSupport = JsonSupportMock.instance(jsonWebKeySetTranslations = { _ => Right(jsonWebKeySet) })
 
   val discovery: OpenIdConnectDiscovery[Id] = OpenIdConnectDiscovery.static[Id](OpenIdConfig(issuer = Issuer(""), jwksUrl))
 

--- a/core/src/test/scala/me/wojnowski/oidc4s/mocks/JsonSupportMock.scala
+++ b/core/src/test/scala/me/wojnowski/oidc4s/mocks/JsonSupportMock.scala
@@ -10,10 +10,10 @@ import me.wojnowski.oidc4s.json.JsonSupport
 object JsonSupportMock {
 
   def instance(
-    idTokenTranslations: PartialFunction[String, IdTokenClaims] = PartialFunction.empty,
-    joseHeaderTranslations: PartialFunction[String, JoseHeader] = PartialFunction.empty,
-    openIdConfigTranslations: PartialFunction[String, OpenIdConfig] = PartialFunction.empty,
-    jsonWebKeySetTranslations: PartialFunction[String, JsonWebKeySet] = PartialFunction.empty
+    idTokenTranslations: PartialFunction[String, Either[String, IdTokenClaims]] = PartialFunction.empty,
+    joseHeaderTranslations: PartialFunction[String, Either[String, JoseHeader]] = PartialFunction.empty,
+    openIdConfigTranslations: PartialFunction[String, Either[String, OpenIdConfig]] = PartialFunction.empty,
+    jsonWebKeySetTranslations: PartialFunction[String, Either[String, JsonWebKeySet]] = PartialFunction.empty
   ): JsonSupport = new JsonSupport {
 
     override implicit val joseHeaderDecoder: JsonDecoder[JoseHeader] =
@@ -28,8 +28,8 @@ object JsonSupportMock {
     override implicit val jwksDecoder: JsonDecoder[JsonWebKeySet] =
       translateOrFail(jsonWebKeySetTranslations, "JsonWebKeySet")
 
-    private def translateOrFail[A](translations: PartialFunction[String, A], name: String): JsonDecoder[A] =
-      (rawJson: String) => translations.lift(rawJson.trim).toRight(s"could not find $name for [$rawJson]")
+    private def translateOrFail[A](translations: PartialFunction[String, Either[String, A]], name: String): JsonDecoder[A] =
+      (rawJson: String) => translations.lift(rawJson.trim).toRight(s"could not find $name for [$rawJson]").flatten
   }
 
 }


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/jwojnowski/oidc4s/pull/53#discussion_r1367332450).

While I like the idea of representing only supported algorithms, the error handling becomes... suboptimal, as the implementation-agnostic `JsonDecoder` has a very simple interface (`Either[String, A]`). This means some weird string matching is necessary.

Of course, the error handling could be simplified to `CouldNotDecodeHeader`, perhaps with a hint in a message it might be caused by unsupported algorithm. This would avoid most of the changes from this PR. However, I quite like an explicit `UnsupportedAlgorithm` error, especially one that clearly states which algorithm has been provided.

@majk-p WDYT?