### PR TITLE
Revert "Update scalafmt-core to 3.7.16"

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.16"
+version = "3.7.15"
 runner.dialect = scala213
 maxColumn = 140
 align.preset = some


### PR DESCRIPTION
Reverts jwojnowski/oidc4s#60 because of [failing CI](https://github.com/jwojnowski/oidc4s/actions/runs/6837315701) (scalafmt issue: https://github.com/scalameta/scalafmt/issues/3689).