### PR TITLE
🗑 Deprecate not needed IdTokenVerifierMock Traverse requirement

### DIFF
--- a/testkit/src/main/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMock.scala
+++ b/testkit/src/main/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMock.scala
@@ -86,24 +86,42 @@ object IdTokenVerifierMock {
 
   }
 
+  @deprecated("Use version with explicit client ID")
   def constSubject[F[_]: Applicative: Traverse: Clock](subject: IdTokenClaims.Subject): IdTokenVerifier[F] =
-    constSubjectEither[F](Right(subject))
+    constSubject[F](subject, ClientId("https://example.com"))
 
-  def constSubjectEither[F[_]: Applicative: Traverse: Clock](errorOrSubject: Either[IdTokenVerifier.Error, IdTokenClaims.Subject])
+  def constSubject[F[_]: Applicative: Clock](subject: IdTokenClaims.Subject, clientId: ClientId = ClientId("https://example.com"))
     : IdTokenVerifier[F] =
-    constSubjectPF[F]((_: String) => errorOrSubject)
+    constSubjectEither[F](Right(subject), clientId)
 
+  @deprecated("Use version with explicit client ID")
+  def constSubjectEither[F[_]: Applicative: Traverse: Clock](errorOrSubject: Either[IdTokenVerifier.Error, IdTokenClaims.Subject])
+    : IdTokenVerifier[F] = constSubjectEither[F](errorOrSubject, ClientId("https://example.com"))
+
+  def constSubjectEither[F[_]: Applicative: Clock](
+    errorOrSubject: Either[IdTokenVerifier.Error, IdTokenClaims.Subject],
+    clientId: ClientId = ClientId("https://example.com")
+  ): IdTokenVerifier[F] =
+    constSubjectPF[F]((_: String) => errorOrSubject, clientId)
+
+  @deprecated("Use version with explicit client ID")
   def constSubjectPF[F[_]: Applicative: Traverse: Clock](
     rawTokenToSubjectPF: PartialFunction[String, Either[IdTokenVerifier.Error, IdTokenClaims.Subject]]
   ): IdTokenVerifier[F] =
-    constStandardClaimsEitherPF(
+    constSubjectPF[F](rawTokenToSubjectPF, ClientId("https://example.com"))
+
+  def constSubjectPF[F[_]: Applicative: Clock](
+    rawTokenToSubjectPF: PartialFunction[String, Either[IdTokenVerifier.Error, IdTokenClaims.Subject]],
+    clientId: ClientId = ClientId("https://example.com")
+  ): IdTokenVerifier[F] =
+    constClaimsEitherPF(
       rawTokenToSubjectPF.map { errorOrSubject =>
         Applicative[F].map(Clock[F].realTimeInstant) { now =>
           errorOrSubject.map(subject =>
             IdTokenClaims(
               Issuer("https://example.com"),
               subject,
-              NonEmptySet.of(Audience("https://example.com")),
+              NonEmptySet.of(Audience(clientId.value)),
               expiration = now.plusSeconds(600),
               issuedAt = now
             )
@@ -112,13 +130,25 @@ object IdTokenVerifierMock {
       }
     )
 
-  def constStandardClaims[F[_]: Applicative: Traverse](claims: IdTokenClaims): IdTokenVerifier[F] = constStandardClaimsEither(Right(claims))
+  @deprecated("Use constClaims", "0.12.2")
+  def constStandardClaims[F[_]: Applicative: Traverse](claims: IdTokenClaims): IdTokenVerifier[F] = constClaims(claims)
 
+  @deprecated("Use constClaimsEither", "0.12.2")
   def constStandardClaimsEither[F[_]: Applicative: Traverse](claimsEither: Either[IdTokenVerifier.Error, IdTokenClaims])
     : IdTokenVerifier[F] =
-    constStandardClaimsEitherPF[F](_ => claimsEither.pure[F])
+    constClaimsEither(claimsEither)
 
+  @deprecated("Use constClaimsEitherPF", "0.12.2")
   def constStandardClaimsEitherPF[F[_]: Applicative: Traverse](
+    rawTokenToClaimsPF: PartialFunction[String, F[Either[IdTokenVerifier.Error, IdTokenClaims]]]
+  ): IdTokenVerifier[F] = constClaimsEitherPF(rawTokenToClaimsPF)
+
+  def constClaims[F[_]: Applicative](claims: IdTokenClaims): IdTokenVerifier[F] = constClaimsEither(Right(claims))
+
+  def constClaimsEither[F[_]: Applicative](claimsEither: Either[IdTokenVerifier.Error, IdTokenClaims]): IdTokenVerifier[F] =
+    constClaimsEitherPF[F](_ => claimsEither.pure[F])
+
+  def constClaimsEitherPF[F[_]: Applicative](
     rawTokenToClaimsPF: PartialFunction[String, F[Either[IdTokenVerifier.Error, IdTokenClaims]]]
   ): IdTokenVerifier[F] = new IdTokenVerifier[F] {
 

--- a/testkit/src/test/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMockTest.scala
+++ b/testkit/src/test/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMockTest.scala
@@ -14,7 +14,6 @@ import munit.FunSuite
 import java.time.Instant
 import CirceJsonSupport._
 import cats.data.NonEmptySet
-import cats.data.NonEmptySetImpl
 import cats.effect.Clock
 import me.wojnowski.oidc4s.IdTokenClaims.Audience
 import me.wojnowski.oidc4s.IdTokenClaims.Subject


### PR DESCRIPTION
The previous version of `IdTokenVerifierMock` requires `Traverse`. However, not only there's no `Traverse` for `cats.effect.IO` (which renders 2/3 of the mock methods useless for `IO`), but also the `Traverse` is completely not needed there.

Unfortunately, this is a public API, so the fix has to be binary-compatible. Thankfully, it looks like there's a way of fixing this without weird naming and breaking the compatibility.