### PR TITLE
✨ Add `verifyAndDecode` variant with client check [breaking]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ inThisBuild(
 
 val commonSettings = Seq(
   makePom / publishArtifact := true,
-  mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet
+//  mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet
+  mimaPreviousArtifacts := Set.empty
 )
 
 lazy val Versions = new {

--- a/core/src/main/scala/me/wojnowski/oidc4s/IdTokenVerifier.scala
+++ b/core/src/main/scala/me/wojnowski/oidc4s/IdTokenVerifier.scala
@@ -26,6 +26,9 @@ trait IdTokenVerifier[F[_]] {
   /** Verifies a token is valid. Returns standard Open ID Token claims. Client ID must be checked manually. */
   def verifyAndDecode(rawToken: String): F[Either[IdTokenVerifier.Error, IdTokenClaims]]
 
+  /** Verifies a token is valid. Returns standard Open ID Token claims. Client ID is verified. */
+  def verifyAndDecode(rawToken: String, expectedClientId: ClientId): F[Either[IdTokenVerifier.Error, IdTokenClaims]]
+
   /** Verifies a token is valid. Returns custom type decoded using provided decoder.
     */
   def verifyAndDecodeCustom[A](rawToken: String)(implicit decoder: ClaimsDecoder[A]): F[Either[IdTokenVerifier.Error, A]]
@@ -78,6 +81,11 @@ object IdTokenVerifier {
 
       override def verifyAndDecode(rawToken: String): F[Either[IdTokenVerifier.Error, IdTokenClaims]] =
         verifyAndDecodeCustom[IdTokenClaims](rawToken)(JsonDecoder[IdTokenClaims].decode(_).map(result => (result, result)))
+
+      override def verifyAndDecode(rawToken: String, expectedClientId: ClientId): F[Either[IdTokenVerifier.Error, IdTokenClaims]] =
+        verifyAndDecodeCustom[IdTokenClaims](rawToken, expectedClientId)(
+          JsonDecoder[IdTokenClaims].decode(_).map(result => (result, result))
+        )
 
       override def verifyAndDecodeCustom[A](rawToken: String)(implicit decoder: ClaimsDecoder[A]): F[Either[Error, A]] =
         internalVerifyAndDecode(rawToken, _ => Either.unit)

--- a/core/src/main/scala/me/wojnowski/oidc4s/IdTokenVerifier.scala
+++ b/core/src/main/scala/me/wojnowski/oidc4s/IdTokenVerifier.scala
@@ -42,14 +42,6 @@ trait IdTokenVerifier[F[_]] {
 
 object IdTokenVerifier {
 
-  @deprecated("Use instance", "0.11.0")
-  def create[F[_]: Monad: Clock](
-    publicKeyProvider: PublicKeyProvider[F],
-    discovery: OpenIdConnectDiscovery[F],
-    jsonSupport: JsonSupport
-  ): IdTokenVerifier[F] =
-    this.discovery(publicKeyProvider, discovery, jsonSupport)
-
   def discovery[F[_]: Monad: Clock](
     publicKeyProvider: PublicKeyProvider[F],
     discovery: OpenIdConnectDiscovery[F],

--- a/core/src/main/scala/me/wojnowski/oidc4s/PublicKeyProvider.scala
+++ b/core/src/main/scala/me/wojnowski/oidc4s/PublicKeyProvider.scala
@@ -46,14 +46,6 @@ object PublicKeyProvider {
       .traverse { case (keyId, key) => KeyUtils.parsePublicPemKey(key).map(keyId -> _) }
       .map(keyIdToKeyList => static(keyIdToKeyList.toMap))
 
-  @deprecated("Use discovery", "0.11.0")
-  def jwks[F[_]: Monad](
-    discovery: OpenIdConnectDiscovery[F]
-  )(
-    transport: Transport[F],
-    jsonSupport: JsonSupport
-  ): PublicKeyProvider[F] = this.discovery(discovery)(transport, jsonSupport)
-
   def discovery[F[_]: Monad](
     discovery: OpenIdConnectDiscovery[F]
   )(

--- a/testkit/src/main/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMock.scala
+++ b/testkit/src/main/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMock.scala
@@ -89,29 +89,15 @@ object IdTokenVerifierMock {
 
   }
 
-  @deprecated("Use version with explicit client ID")
-  def constSubject[F[_]: Applicative: Traverse: Clock](subject: IdTokenClaims.Subject): IdTokenVerifier[F] =
-    constSubject[F](subject, ClientId("https://example.com"))
-
   def constSubject[F[_]: Applicative: Clock](subject: IdTokenClaims.Subject, clientId: ClientId = ClientId("https://example.com"))
     : IdTokenVerifier[F] =
     constSubjectEither[F](Right(subject), clientId)
-
-  @deprecated("Use version with explicit client ID")
-  def constSubjectEither[F[_]: Applicative: Traverse: Clock](errorOrSubject: Either[IdTokenVerifier.Error, IdTokenClaims.Subject])
-    : IdTokenVerifier[F] = constSubjectEither[F](errorOrSubject, ClientId("https://example.com"))
 
   def constSubjectEither[F[_]: Applicative: Clock](
     errorOrSubject: Either[IdTokenVerifier.Error, IdTokenClaims.Subject],
     clientId: ClientId = ClientId("https://example.com")
   ): IdTokenVerifier[F] =
     constSubjectPF[F]((_: String) => errorOrSubject, clientId)
-
-  @deprecated("Use version with explicit client ID")
-  def constSubjectPF[F[_]: Applicative: Traverse: Clock](
-    rawTokenToSubjectPF: PartialFunction[String, Either[IdTokenVerifier.Error, IdTokenClaims.Subject]]
-  ): IdTokenVerifier[F] =
-    constSubjectPF[F](rawTokenToSubjectPF, ClientId("https://example.com"))
 
   def constSubjectPF[F[_]: Applicative: Clock](
     rawTokenToSubjectPF: PartialFunction[String, Either[IdTokenVerifier.Error, IdTokenClaims.Subject]],
@@ -132,19 +118,6 @@ object IdTokenVerifierMock {
         }
       }
     )
-
-  @deprecated("Use constClaims", "0.12.2")
-  def constStandardClaims[F[_]: Applicative: Traverse](claims: IdTokenClaims): IdTokenVerifier[F] = constClaims(claims)
-
-  @deprecated("Use constClaimsEither", "0.12.2")
-  def constStandardClaimsEither[F[_]: Applicative: Traverse](claimsEither: Either[IdTokenVerifier.Error, IdTokenClaims])
-    : IdTokenVerifier[F] =
-    constClaimsEither(claimsEither)
-
-  @deprecated("Use constClaimsEitherPF", "0.12.2")
-  def constStandardClaimsEitherPF[F[_]: Applicative: Traverse](
-    rawTokenToClaimsPF: PartialFunction[String, F[Either[IdTokenVerifier.Error, IdTokenClaims]]]
-  ): IdTokenVerifier[F] = constClaimsEitherPF(rawTokenToClaimsPF)
 
   def constClaims[F[_]: Applicative](claims: IdTokenClaims): IdTokenVerifier[F] = constClaimsEither(Right(claims))
 

--- a/testkit/src/main/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMock.scala
+++ b/testkit/src/main/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMock.scala
@@ -50,6 +50,9 @@ object IdTokenVerifierMock {
         }
         .pure[F]
 
+    override def verifyAndDecode(rawToken: String, expectedClientId: ClientId): F[Either[IdTokenVerifier.Error, IdTokenClaims]] =
+      verifyAndDecode(rawToken).map(_.filterOrElse(_.matchesClientId(expectedClientId), IdTokenVerifier.Error.ClientIdDoesNotMatch))
+
     override def verifyAndDecodeCustom[A](rawToken: String)(implicit decoder: ClaimsDecoder[A]): F[Either[IdTokenVerifier.Error, A]] =
       rawTokenToRawClaimsEither
         .lift(rawToken)
@@ -159,6 +162,9 @@ object IdTokenVerifierMock {
           .toRight(IdTokenVerifier.Error.MalformedToken: IdTokenVerifier.Error)
           .sequence
       )(_.flatten)
+
+    override def verifyAndDecode(rawToken: String, expectedClientId: ClientId): F[Either[IdTokenVerifier.Error, IdTokenClaims]] =
+      verifyAndDecode(rawToken).map(_.filterOrElse(_.matchesClientId(expectedClientId), IdTokenVerifier.Error.ClientIdDoesNotMatch))
 
     override def verify(rawToken: String, expectedClientId: ClientId): F[Either[IdTokenVerifier.Error, IdTokenClaims.Subject]] =
       Applicative[F].map(verifyAndDecode(rawToken)) {

--- a/testkit/src/test/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMockTest.scala
+++ b/testkit/src/test/scala/me/wojnowski/oidc4s/testkit/IdTokenVerifierMockTest.scala
@@ -31,7 +31,7 @@ class IdTokenVerifierMockTest extends FunSuite {
     case `expiredToken` => Left(IdTokenVerifier.Error.TokenExpired(Instant.EPOCH.plusSeconds(30)))
   }
 
-  val standardClaimsMock: IdTokenVerifier[Id] = IdTokenVerifierMock.constStandardClaimsEitherPF {
+  val standardClaimsMock: IdTokenVerifier[Id] = IdTokenVerifierMock.constClaimsEitherPF {
     case `token1`       => Right(standardClaims1)
     case `expiredToken` => Left(IdTokenVerifier.Error.TokenExpired(Instant.EPOCH.plusSeconds(2237)))
   }


### PR DESCRIPTION
```scala
def verifyAndDecode(rawToken: String, expectedClientId: ClientId): F[Either[IdTokenVerifier.Error, IdTokenClaims]]
```
was missing and it can be quite useful.

Since that's (apparently) a breaking change, some deprecated code was also removed in preparation for `0.13.x`.